### PR TITLE
feat: Implement variable validation and refine image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,12 @@ You can specify a config file with the `--config` flag.
 
 ## API Reference
 
-- **`GET /metadata`**: Returns JSON describing all variables, dimensions, and attributes of the loaded file.
-- **`GET /point`**: Returns interpolated values for one or more variables at a specific point in space-time.
-- **`GET /image`**: Returns a PNG/JPEG image rendering of a variable over a specified region and time.
+- **`GET /metadata`**: Returns JSON describing all variables, dimensions, and attributes of the loaded NetCDF file.
+- **`GET /point`**: Returns interpolated values for one or more variables at a specific point in space-time. Requested `vars` are validated against the NetCDF file's metadata.
+  - `lon`, `lat`: (required) Longitude and latitude coordinates.
+  - `time_index`: (optional) Time index (0-based), defaults to 0.
+  - `vars`: (required) Comma-separated list of variable names to query.
+  - `interpolation`: (optional) Interpolation method ("nearest", "bilinear", "bicubic"), defaults to "bilinear".
 - **`GET /heartbeat`**: Returns server status information including uptime, memory usage, and dataset details.
   - Response includes:
     - `server_id`: Unique identifier for this server instance
@@ -147,20 +150,19 @@ You can specify a config file with the `--config` flag.
       - `dimension_count`: Number of dimensions
       - `dimensions`: List of dimension names and sizes
       - `data_memory_bytes`: Approximate memory usage of the dataset
-      
-- **`GET /image`**: Returns a PNG/JPEG image rendering of a variable over a specified region and time.
-  - `var`: (required) Variable name to render
-  - `time_index`: (optional) Time index, defaults to 0
-  - `bbox`: (optional) Bounding box as "min_lon,min_lat,max_lon,max_lat"
+- **`GET /image`**: Returns a PNG/JPEG image rendering of a variable over a specified region and time. The requested `var` is validated against the NetCDF file's metadata. This endpoint is intended for rendering variables that represent data on a 2D latitude-longitude grid.
+  - `var`: (required) Variable name to render.
+  - `time_index`: (optional) Time index, defaults to 0.
+  - `bbox`: (optional) Bounding box as "min_lon,min_lat,max_lon,max_lat".
   - `width`: (optional) Image width in pixels, defaults to 800
   - `height`: (optional) Image height in pixels, defaults to 600
   - `colormap`: (optional) Colormap name (e.g., viridis, plasma, coolwarm), defaults to "viridis"
   - `format`: (optional) Output format: "png" or "jpeg", defaults to "png"
   - `center`: (optional) Map centering: "eurocentric" (-180° to 180°), "americas" (-90° to 270°), "pacific" (0° to 360°), or a custom longitude value, defaults to "eurocentric"
-  - `wrap_longitude`: (optional) Allow bounding boxes that cross the dateline/prime meridian, defaults to false
-  - `resampling`: (optional) Upsampling/downsampling quality: "nearest", "bilinear", "bicubic", or "auto", defaults to "auto" (bilinear)
+  - `wrap_longitude`: (optional) Allow bounding boxes that cross the dateline/prime meridian, defaults to false.
+  - `resampling`: (optional) Upsampling/downsampling quality: "nearest", "bilinear", "bicubic", or "auto", defaults to "auto" (bilinear).
 
-For full details, see the [design.md](https://www.google.com/search?q=design.md) document.
+For full details, see the `doc/design.md` document.
 
 ## Building from Source
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,14 @@ pub enum RossbyError {
     #[error("Variable not found: {name}")]
     VariableNotFound { name: String },
 
+    /// Invalid variables errors
+    #[error("Invalid variable(s): [{}]", names.join(", "))]
+    InvalidVariables { names: Vec<String> },
+
+    /// Variable not suitable for image rendering
+    #[error("Variable {name} is not suitable for image rendering. It must be a 2D grid with latitude and longitude dimensions.")]
+    VariableNotSuitableForImage { name: String },
+
     /// Index out of bounds errors
     #[error("Index out of bounds: {param}={value}, max allowed is {max}")]
     IndexOutOfBounds {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,26 +11,25 @@ use std::sync::Once;
 // Global test setup for server
 use once_cell::sync::OnceCell;
 
-static INIT: Once = Once::new();
-static TEST_ADDR: OnceCell<SocketAddr> = OnceCell::new();
-static TEST_TEMP_DIR: OnceCell<tempfile::TempDir> = OnceCell::new();
-static TEST_FILE_PATH: OnceCell<String> = OnceCell::new();
+static TEST_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-/// Start a test server on a specified port
-async fn start_test_server() -> SocketAddr {
-    // Initialize test data and get temp directory
-    let _temp_dir = TEST_TEMP_DIR.get_or_init(|| {
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test_weather.nc");
-        test_data::create_test_weather_nc(&file_path).unwrap();
+/// Creates a unique directory for each test server instance.
+fn create_unique_temp_dir_and_file(
+    generator_fn: fn(&std::path::Path) -> netcdf::Result<()>,
+) -> (tempfile::TempDir, String) {
+    let count = TEST_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let file_name = format!("test_data_{}.nc", count);
+    let file_path = dir.path().join(file_name);
+    generator_fn(&file_path).expect("Failed to create test NC file");
+    (dir, file_path.to_string_lossy().to_string())
+}
 
-        // Save the path for later reference
-        TEST_FILE_PATH
-            .set(file_path.to_string_lossy().to_string())
-            .unwrap();
-
-        dir
-    });
+/// Start a test server with a specific data generator function.
+async fn start_test_server_with_data(
+    generator_fn: fn(&std::path::Path) -> netcdf::Result<()>,
+) -> SocketAddr {
+    let (_temp_dir, file_path) = create_unique_temp_dir_and_file(generator_fn);
 
     // Use port 0 to let the OS assign an available port
     let addr = SocketAddr::from((std::net::Ipv4Addr::new(127, 0, 0, 1), 0));
@@ -43,16 +42,13 @@ async fn start_test_server() -> SocketAddr {
     // Get the actual bound address with the OS-assigned port
     let bound_addr = listener.local_addr().expect("Failed to get local address");
 
-    // Get the test file path
-    let file_path = TEST_FILE_PATH.get().expect("Test file path not set");
-
     // Start the server
     tokio::spawn(async move {
         // Create a minimal config
         let config = rossby::Config {
             server: rossby::config::ServerConfig {
                 host: "127.0.0.1".to_string(),
-                port: bound_addr.port(),
+                port: bound_addr.port(), // Use the OS-assigned port
                 workers: Some(1),
                 discovery_url: None,
             },
@@ -60,9 +56,11 @@ async fn start_test_server() -> SocketAddr {
         };
 
         // Load the test NetCDF file
-        let app_state =
-            rossby::data_loader::load_netcdf(std::path::Path::new(file_path), config.clone())
-                .expect("Failed to load test NetCDF file");
+        let app_state = rossby::data_loader::load_netcdf(
+            std::path::Path::new(&file_path), // Use the generated file path
+            config.clone(),
+        )
+        .expect("Failed to load test NetCDF file");
 
         let state = std::sync::Arc::new(app_state);
 
@@ -98,13 +96,19 @@ async fn start_test_server() -> SocketAddr {
     bound_addr
 }
 
-/// Initialize a new test server for each test
+/// Initialize a new test server for each test using the default weather data
 async fn init_test_environment() -> SocketAddr {
-    // Always start a new server for each test
-    let server_addr = start_test_server().await;
+    init_test_environment_with_data_generator(test_data::create_test_weather_nc).await
+}
+
+/// Initialize a new test server with a specific data generator function
+async fn init_test_environment_with_data_generator(
+    generator_fn: fn(&std::path::Path) -> netcdf::Result<()>,
+) -> SocketAddr {
+    let server_addr = start_test_server_with_data(generator_fn).await;
 
     println!(
-        "Test server started, waiting for it to be ready at {}",
+        "Test server with custom data started, waiting for it to be ready at {}",
         server_addr
     );
 
@@ -138,6 +142,162 @@ async fn init_test_environment() -> SocketAddr {
     }
 
     server_addr
+}
+
+#[tokio::test]
+async fn test_point_variable_validation() {
+    let addr = init_test_environment().await; // Uses default test_weather.nc
+
+    // 1. Single valid variable
+    let response = http_client::get(
+        &addr,
+        "/point?lon=-170.0&lat=10.0&vars=temperature",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 200);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    assert!(json.get("temperature").is_some());
+
+    // 2. Multiple valid variables
+    let response = http_client::get(
+        &addr,
+        "/point?lon=-170.0&lat=10.0&vars=temperature,humidity",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 200);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    assert!(json.get("temperature").is_some());
+    assert!(json.get("humidity").is_some());
+
+    // 3. Single invalid variable
+    let response = http_client::get(
+        &addr,
+        "/point?lon=-170.0&lat=10.0&vars=nonexistent_var",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 400);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    assert_eq!(
+        json["error"],
+        "Invalid variable(s): [nonexistent_var]"
+    );
+
+    // 4. Multiple variables, one invalid
+    let response = http_client::get(
+        &addr,
+        "/point?lon=-170.0&lat=10.0&vars=temperature,nonexistent_var",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 400);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    assert_eq!(
+        json["error"],
+        "Invalid variable(s): [nonexistent_var]"
+    );
+
+    // 5. Multiple variables, multiple invalid
+    let response = http_client::get(
+        &addr,
+        "/point?lon=-170.0&lat=10.0&vars=temperature,fake1,humidity,fake2",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 400);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    // The order of invalid variables might not be guaranteed, so check for presence
+    let error_msg = json["error"].as_str().unwrap();
+    assert!(error_msg.starts_with("Invalid variable(s): ["));
+    assert!(error_msg.contains("fake1"));
+    assert!(error_msg.contains("fake2"));
+    assert!(error_msg.ends_with("]"));
+}
+
+#[tokio::test]
+async fn test_image_variable_validation() {
+    let addr = init_test_environment().await; // Uses default test_weather.nc
+
+    // 1. Valid variable
+    let response = http_client::get(
+        &addr,
+        "/image?var=temperature&time_index=0&width=10&height=10",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.headers().get("content-type").unwrap(), "image/png");
+
+    // 2. Invalid variable
+    let response = http_client::get(
+        &addr,
+        "/image?var=nonexistent_var&time_index=0&width=10&height=10",
+    )
+    .await
+    .expect("Request failed");
+    assert_eq!(response.status(), 400);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+    assert_eq!(
+        json["error"],
+        "Invalid variable(s): [nonexistent_var]"
+    );
+}
+
+#[tokio::test]
+async fn test_image_rendering_suitability() {
+    let addr =
+        init_test_environment_with_data_generator(test_data::create_varied_content_nc).await;
+
+    // 1. Valid 2D spatial variable (temp_map_2d)
+    let response = http_client::get(
+        &addr,
+        "/image?var=temp_map_2d&width=10&height=10", // No time_index needed as it's 2D
+    )
+    .await
+    .expect("Request failed for temp_map_2d");
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.headers().get("content-type").unwrap(), "image/png");
+
+    // 2. Valid 3D spatial variable (temp_3d_var), will be sliced by time_index=0 default
+    let response = http_client::get(
+        &addr,
+        "/image?var=temp_3d_var&width=10&height=10",
+    )
+    .await
+    .expect("Request failed for temp_3d_var");
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.headers().get("content-type").unwrap(), "image/png");
+
+
+    // 3. 1D variable (time_profile_1d) - Not suitable
+    let response = http_client::get(
+        &addr,
+        "/image?var=time_profile_1d&width=10&height=10",
+    )
+    .await
+    .expect("Request failed for time_profile_1d");
+    assert_eq!(response.status(), 400);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON for time_profile_1d");
+    assert_eq!(
+        json["error"],
+        "Variable time_profile_1d is not suitable for image rendering. It must be a 2D grid with latitude and longitude dimensions."
+    );
+
+    // 4. 2D non-spatial variable (level_data_2d) - Not suitable
+    let response = http_client::get(
+        &addr,
+        "/image?var=level_data_2d&width=10&height=10",
+    )
+    .await
+    .expect("Request failed for level_data_2d");
+    assert_eq!(response.status(), 400);
+    let json: serde_json::Value = response.json().await.expect("Failed to parse JSON for level_data_2d");
+    assert_eq!(
+        json["error"],
+        "Variable level_data_2d is not suitable for image rendering. It must be a 2D grid with latitude and longitude dimensions."
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
This commit introduces two main enhancements:

1.  **Variable Validation**:
    - The `/point` and `/image` API endpoints now validate requested variable names against the metadata of the loaded NetCDF file.
    - If one or more requested variables are not found, the API returns a 400 Bad Request error with a JSON message listing the invalid variables.
    - This prevents errors and provides clearer feedback to you when requesting non-existent variables.

2.  **Image Rendering Suitability**:
    - The `/image` endpoint has been refined to ensure it primarily renders data from 2D latitude-longitude grids.
    - It now checks if the requested variable has at least two dimensions and if these dimensions can be identified as spatial (latitude and longitude) based on dimension names or coordinate variable attributes (units, standard_name).
    - If a variable is deemed unsuitable for image rendering (e.g., it's 1D data or a 2D non-spatial grid), the API returns a 400 Bad Request error with a descriptive message.

Associated changes:
- Updated `README.md` and `doc/design.md` to reflect these new validation mechanisms and rendering constraints.
- Added comprehensive integration tests to verify the new validation logic for both `/point` and `/image` endpoints, including various valid and invalid scenarios.
- Added integration tests to confirm the image rendering suitability checks, using a new test NetCDF file with diverse variable types (1D, 2D spatial, 3D spatial, 2D non-spatial).
- Enhanced the test infrastructure to allow initializing the test server with different NetCDF data generators, facilitating more targeted testing.
- Introduced new error variants in `RossbyError` for invalid variables and variables unsuitable for imaging.