### PR TITLE
Ignore configured NetCDF variables during loading

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,15 @@ pub struct Args {
     /// Service discovery URL for registering this server
     #[arg(long, env = "ROSSBY_DISCOVERY_URL")]
     pub discovery_url: Option<String>,
+
+    /// Variable names to ignore during NetCDF loading
+    #[arg(
+        long = "ignore-variable",
+        env = "ROSSBY_IGNORE_VARIABLES",
+        value_delimiter = ',',
+        action = clap::ArgAction::Append
+    )]
+    pub ignore_variables: Vec<String>,
 }
 
 /// Server configuration
@@ -85,6 +94,10 @@ pub struct DataConfig {
     /// For example: {"latitude": "lat", "longitude": "lon", "time": "t"}
     #[serde(default)]
     pub dimension_aliases: HashMap<String, String>,
+
+    /// Variable names to ignore during NetCDF loading
+    #[serde(default)]
+    pub ignore_variables: Vec<String>,
 }
 
 /// Complete configuration
@@ -127,6 +140,9 @@ impl Config {
             config.server.discovery_url = args.discovery_url;
         }
         config.log_level = args.log_level;
+        if !args.ignore_variables.is_empty() {
+            config.data.ignore_variables.extend(args.ignore_variables);
+        }
 
         // NetCDF file path from command line takes precedence
         let netcdf_path = args.netcdf_file;
@@ -226,6 +242,7 @@ impl Default for DataConfig {
             interpolation_method: default_interpolation(),
             file_path: None,
             dimension_aliases: HashMap::new(),
+            ignore_variables: Vec::new(),
         }
     }
 }
@@ -261,6 +278,7 @@ mod tests {
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 8000);
         assert_eq!(config.data.interpolation_method, "bilinear");
+        assert!(config.data.ignore_variables.is_empty());
         assert_eq!(config.log_level, "info");
     }
 
@@ -271,11 +289,13 @@ mod tests {
 
         config2.server.port = 9000;
         config2.server.workers = Some(4);
+        config2.data.ignore_variables = vec!["scalar".to_string()];
 
         config1.merge(config2);
 
         assert_eq!(config1.server.port, 9000);
         assert_eq!(config1.server.workers, Some(4));
+        assert_eq!(config1.data.ignore_variables, vec!["scalar"]);
     }
 
     #[test]

--- a/src/data_loader.rs
+++ b/src/data_loader.rs
@@ -6,7 +6,7 @@
 
 use ndarray::{Array, Dim, IxDyn};
 use netcdf::{self, Attribute, Variable as NetCDFVariable};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use tracing::{debug, info, warn};
 
@@ -19,8 +19,10 @@ pub type LoadResult = Result<(Metadata, HashMap<String, Array<f32, IxDyn>>)>;
 
 /// Load a NetCDF file into memory and create the application state
 pub fn load_netcdf(path: &Path, config: Config) -> Result<AppState> {
+    let ignored_variables = build_ignored_variable_set(&config);
+
     // Load the NetCDF data and metadata
-    let (metadata, data) = load_netcdf_file(path)?;
+    let (metadata, data) = load_netcdf_file(path, &ignored_variables)?;
 
     // Validate the loaded data
     validate_netcdf_data(&metadata, &data)?;
@@ -32,7 +34,7 @@ pub fn load_netcdf(path: &Path, config: Config) -> Result<AppState> {
 }
 
 /// Load a NetCDF file into memory, returning metadata and data
-fn load_netcdf_file(path: &Path) -> LoadResult {
+fn load_netcdf_file(path: &Path, ignored_variables: &HashSet<String>) -> LoadResult {
     // Check if the file exists
     if !path.exists() {
         return Err(RossbyError::Io(std::io::Error::new(
@@ -58,7 +60,7 @@ fn load_netcdf_file(path: &Path) -> LoadResult {
     debug!("File has {} dimensions", dimensions_count);
 
     // Extract file metadata
-    let metadata = extract_metadata(&file)?;
+    let metadata = extract_metadata(&file, ignored_variables)?;
 
     // Extract data from variables
     let data = extract_data(&file, &metadata)?;
@@ -67,7 +69,7 @@ fn load_netcdf_file(path: &Path) -> LoadResult {
 }
 
 /// Extract metadata from the NetCDF file
-fn extract_metadata(file: &netcdf::File) -> Result<Metadata> {
+fn extract_metadata(file: &netcdf::File, ignored_variables: &HashSet<String>) -> Result<Metadata> {
     // Extract global attributes
     let mut global_attributes = HashMap::new();
     for attr in file.attributes() {
@@ -91,9 +93,16 @@ fn extract_metadata(file: &netcdf::File) -> Result<Metadata> {
     let mut coordinates = HashMap::new();
 
     for var in file.variables() {
+        let var_name = var.name();
+
+        if ignored_variables.contains(var_name.as_str()) {
+            warn!("Ignoring variable from config: {}", var_name);
+            continue;
+        }
+
         // Skip variables we can't handle (non-numeric types)
         if !is_supported_variable(&var) {
-            warn!("Skipping unsupported variable: {}", var.name());
+            warn!("Skipping unsupported variable: {}", var_name);
             continue;
         }
 
@@ -119,20 +128,20 @@ fn extract_metadata(file: &netcdf::File) -> Result<Metadata> {
 
         // Create variable metadata
         let variable = Variable {
-            name: var.name().to_string(),
+            name: var_name.clone(),
             dimensions: var_dims,
             shape: var_shape,
             attributes: var_attrs,
             dtype: format!("{:?}", var.vartype()),
         };
 
-        variables.insert(var.name().to_string(), variable);
+        variables.insert(var_name.clone(), variable);
 
         // If this is a coordinate variable (name matches a dimension),
         // extract the coordinate values
-        if file.dimension(&var.name()).is_some() {
+        if file.dimension(&var_name).is_some() {
             let coord_values = extract_coordinate_values(&var)?;
-            coordinates.insert(var.name().to_string(), coord_values);
+            coordinates.insert(var_name, coord_values);
         }
     }
 
@@ -154,6 +163,17 @@ fn extract_metadata(file: &netcdf::File) -> Result<Metadata> {
         variables,
         coordinates,
     })
+}
+
+fn build_ignored_variable_set(config: &Config) -> HashSet<String> {
+    config
+        .data
+        .ignore_variables
+        .iter()
+        .map(|name| name.trim())
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 /// Check if a variable has a supported type that we can work with
@@ -490,6 +510,19 @@ fn create_test_netcdf_file(path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+fn create_test_netcdf_file_with_scalar_variable(path: &Path) -> Result<()> {
+    create_test_netcdf_file(path)?;
+
+    let mut file = netcdf::append(path)?;
+    let mut scalar_var = file.add_variable::<f32>("scalar", &[] as &[&str])?;
+    scalar_var.put_attribute("long_name", "Scalar variable without dimensions")?;
+    scalar_var.put_value(42.0f32, &[] as &[usize])?;
+    file.sync()?;
+
+    Ok(())
+}
+
 /// Validate the loaded NetCDF data for consistency
 fn validate_netcdf_data(
     metadata: &Metadata,
@@ -587,7 +620,7 @@ mod tests {
         println!("Loading real climate data from: {}", file_path.display());
 
         // Load the file
-        let (metadata, data) = load_netcdf_file(file_path)?;
+        let (metadata, data) = load_netcdf_file(file_path, &HashSet::new())?;
 
         // Verify dimensions
         assert!(metadata.dimensions.contains_key("time"));
@@ -717,7 +750,7 @@ mod tests {
 
     #[test]
     fn test_file_not_found() {
-        let result = load_netcdf_file(Path::new("/nonexistent/file.nc"));
+        let result = load_netcdf_file(Path::new("/nonexistent/file.nc"), &HashSet::new());
         assert!(result.is_err());
         match result.unwrap_err() {
             RossbyError::Io(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
@@ -735,7 +768,7 @@ mod tests {
         create_test_netcdf_file(&file_path)?;
 
         // Load the file
-        let (metadata, data) = load_netcdf_file(&file_path)?;
+        let (metadata, data) = load_netcdf_file(&file_path, &HashSet::new())?;
 
         // Simplified verification based on our new test file structure
         assert!(metadata.global_attributes.contains_key("title"));
@@ -782,7 +815,7 @@ mod tests {
 
         // Load the file with debugging
         println!("Loading NetCDF file for attribute test");
-        let (metadata, _) = load_netcdf_file(&file_path)?;
+        let (metadata, _) = load_netcdf_file(&file_path, &HashSet::new())?;
         println!("File loaded successfully");
 
         // Debugging output
@@ -842,7 +875,7 @@ mod tests {
 
         // Load the file with debugging
         println!("Loading NetCDF file for validation test");
-        let (metadata, data) = load_netcdf_file(&file_path)?;
+        let (metadata, data) = load_netcdf_file(&file_path, &HashSet::new())?;
         println!("File loaded successfully");
 
         // Print debugging information
@@ -861,6 +894,45 @@ mod tests {
         }
 
         assert!(validation_result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scalar_variable_requires_ignore_list() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_scalar.nc");
+        create_test_netcdf_file_with_scalar_variable(&file_path)?;
+
+        let result = load_netcdf(&file_path, Config::default());
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            RossbyError::DataNotFound { message } => {
+                assert!(message.contains("scalar"));
+                assert!(message.contains("has no dimensions"));
+            }
+            other => panic!("Expected DataNotFound error, got {:?}", other),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ignore_variables_excludes_scalar_variable_from_processing() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_scalar_ignored.nc");
+        create_test_netcdf_file_with_scalar_variable(&file_path)?;
+
+        let mut config = Config::default();
+        config.data.ignore_variables = vec!["scalar".to_string()];
+
+        let app_state = load_netcdf(&file_path, config)?;
+
+        assert!(!app_state.metadata.variables.contains_key("scalar"));
+        assert!(!app_state.data.contains_key("scalar"));
+        assert!(app_state.metadata.variables.contains_key("temperature"));
+        assert!(app_state.data.contains_key("temperature"));
 
         Ok(())
     }


### PR DESCRIPTION
Summary
- add CLI/config options plus serde fields to list variables to skip when loading NetCDF files
- propagate ignore list through metadata extraction and data loading while warning on ignored names
- extend config tests and add coverage for ignoring scalar variables that would otherwise fail
Testing
