### PR TITLE
Allow scalar NetCDF variables through data loader and exporters

### DIFF
--- a/src/data_loader.rs
+++ b/src/data_loader.rs
@@ -504,13 +504,6 @@ fn validate_netcdf_data(
 
     // Check if dimensions match variables
     for (var_name, var) in &metadata.variables {
-        // Check that the variable has dimensions
-        if var.dimensions.is_empty() {
-            return Err(RossbyError::DataNotFound {
-                message: format!("Variable {} has no dimensions", var_name),
-            });
-        }
-
         // Check that all dimensions exist
         for dim_name in &var.dimensions {
             if !metadata.dimensions.contains_key(dim_name) {
@@ -861,6 +854,36 @@ mod tests {
         }
 
         assert!(validation_result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scalar_variable_loading() -> Result<()> {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("scalar.nc");
+
+        let mut file = netcdf::create(&file_path)?;
+        file.add_attribute("title", "Scalar Test File")?;
+
+        {
+            let mut scalar_var = file.add_variable::<f32>("offset", &[])?;
+            scalar_var.put_attribute("units", "K")?;
+            scalar_var.put_value(42.5f32, ())?;
+        }
+
+        file.sync()?;
+
+        let (metadata, data) = load_netcdf_file(&file_path)?;
+        validate_netcdf_data(&metadata, &data)?;
+
+        let offset_meta = metadata.variables.get("offset").unwrap();
+        assert!(offset_meta.dimensions.is_empty());
+        assert!(offset_meta.shape.is_empty());
+
+        let offset_data = data.get("offset").unwrap();
+        assert_eq!(offset_data.shape(), &[] as &[usize]);
+        assert_eq!(offset_data.iter().copied().collect::<Vec<_>>(), vec![42.5]);
 
         Ok(())
     }

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -276,13 +276,6 @@ fn process_data_query_json(state: Arc<AppState>, params: DataQuery) -> Result<Re
             if dim_result.is_err() {
                 debug!("Failed to resolve dimension: {} - {:?}", dim, dim_result);
 
-                // Check if this is a canonical name that we should accept
-                let canonical_dims = ["latitude", "longitude", "time", "level"];
-                if canonical_dims.contains(&dim.as_str()) {
-                    debug!("Accepting canonical dimension name: {}", dim);
-                    continue; // Accept canonical names even if they don't resolve
-                }
-
                 return Err(RossbyError::InvalidParameter {
                     param: "layout".to_string(),
                     message: format!("Unknown dimension in layout: {}", dim),
@@ -659,13 +652,6 @@ fn process_data_query(state: Arc<AppState>, params: DataQuery) -> Result<Vec<u8>
 
             if dim_result.is_err() {
                 debug!("Failed to resolve dimension: {} - {:?}", dim, dim_result);
-
-                // Check if this is a canonical name that we should accept
-                let canonical_dims = ["latitude", "longitude", "time", "level"];
-                if canonical_dims.contains(&dim.as_str()) {
-                    debug!("Accepting canonical dimension name: {}", dim);
-                    continue; // Accept canonical names even if they don't resolve
-                }
 
                 return Err(RossbyError::InvalidParameter {
                     param: "layout".to_string(),

--- a/src/handlers/data.rs
+++ b/src/handlers/data.rs
@@ -382,18 +382,13 @@ fn create_json_stream(
         }
     }
 
-    // For dimensions not explicitly selected, use the entire range
-    for (dim_name, dim) in &state.metadata.dimensions {
-        if !selected_ranges.contains_key(dim_name) {
-            selected_ranges.insert(dim_name.clone(), (0, dim.size - 1));
-            if let Some(coords) = state.get_coordinate(dim_name) {
-                coordinate_arrays.insert(dim_name.clone(), coords.clone());
-            } else {
-                let indices: Vec<f64> = (0..dim.size).map(|i| i as f64).collect();
-                coordinate_arrays.insert(dim_name.clone(), indices);
-            }
-        }
-    }
+    let dimension_order = determine_dimension_order(&state, &variables, layout.as_ref())?;
+    populate_query_coordinates(
+        &state,
+        &dimension_order,
+        &mut selected_ranges,
+        &mut coordinate_arrays,
+    )?;
 
     // Calculate the total number of data points to check against limit
     let total_points: usize = coordinate_arrays
@@ -421,23 +416,7 @@ fn create_json_stream(
         let var_meta = state.get_variable_metadata_checked(var_name)?;
         var_metadata.push((var_name.clone(), var_meta));
     }
-
-    // Get dimensions based on the first variable for use in metadata
-    let dimension_order = if let Some(layout_dims) = &layout {
-        layout_dims
-            .iter()
-            .map(|dim| state.resolve_dimension(dim).unwrap_or(dim).to_string())
-            .collect::<Vec<_>>()
-    } else if !variables.is_empty() {
-        // Use dimensions from the first variable
-        let var_meta = state.get_variable_metadata_checked(&variables[0])?;
-        var_meta.dimensions.clone()
-    } else {
-        return Err(RossbyError::InvalidParameter {
-            param: "vars".to_string(),
-            message: "No valid variables specified".to_string(),
-        });
-    };
+    normalize_variable_arrays(&state, &variables, &mut var_data_arrays)?;
 
     // Prepare shape information for metadata
     let shapes: Vec<Vec<usize>> = var_data_arrays
@@ -899,6 +878,124 @@ fn process_dimension_constraints(
     Ok(selectors)
 }
 
+fn determine_dimension_order(
+    state: &AppState,
+    variables: &[String],
+    layout: Option<&Vec<String>>,
+) -> Result<Vec<String>> {
+    if let Some(layout_dims) = layout {
+        return Ok(layout_dims
+            .iter()
+            .map(|dim| state.resolve_dimension(dim).unwrap_or(dim).to_string())
+            .collect());
+    }
+
+    for var_name in variables {
+        let var_meta = state.get_variable_metadata_checked(var_name)?;
+        if !var_meta.dimensions.is_empty() {
+            return Ok(var_meta.dimensions.clone());
+        }
+    }
+
+    Ok(Vec::new())
+}
+
+fn populate_query_coordinates(
+    state: &AppState,
+    dimension_order: &[String],
+    selected_ranges: &mut HashMap<String, (usize, usize)>,
+    coordinate_arrays: &mut HashMap<String, Vec<f64>>,
+) -> Result<()> {
+    for dim_name in dimension_order {
+        if !selected_ranges.contains_key(dim_name) {
+            let dim = state.metadata.dimensions.get(dim_name).ok_or_else(|| {
+                RossbyError::DataNotFound {
+                    message: format!("Dimension {} not found in metadata", dim_name),
+                }
+            })?;
+
+            let end = dim
+                .size
+                .checked_sub(1)
+                .ok_or_else(|| RossbyError::DataNotFound {
+                    message: format!("Dimension {} is empty", dim_name),
+                })?;
+            selected_ranges.insert(dim_name.clone(), (0, end));
+        }
+
+        if coordinate_arrays.contains_key(dim_name) {
+            continue;
+        }
+
+        let (start, end) = selected_ranges[dim_name];
+        if let Some(coords) = state.get_coordinate(dim_name) {
+            if end >= coords.len() {
+                return Err(RossbyError::IndexOutOfBounds {
+                    param: dim_name.clone(),
+                    value: format!("{}..{}", start, end),
+                    max: coords.len().saturating_sub(1),
+                });
+            }
+            coordinate_arrays.insert(dim_name.clone(), coords[start..=end].to_vec());
+        } else {
+            let indices: Vec<f64> = (start..=end).map(|i| i as f64).collect();
+            coordinate_arrays.insert(dim_name.clone(), indices);
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_variable_arrays(
+    state: &AppState,
+    variables: &[String],
+    data_arrays: &mut [Array<f32, IxDyn>],
+) -> Result<()> {
+    let reference_shape = variables
+        .iter()
+        .zip(data_arrays.iter())
+        .find_map(|(var_name, array)| {
+            state
+                .get_variable_metadata_checked(var_name)
+                .ok()
+                .filter(|meta| !meta.dimensions.is_empty())
+                .map(|_| array.shape().to_vec())
+        });
+
+    let Some(reference_shape) = reference_shape else {
+        return Ok(());
+    };
+
+    for (var_name, array) in variables.iter().zip(data_arrays.iter_mut()) {
+        let var_meta = state.get_variable_metadata_checked(var_name)?;
+        if var_meta.dimensions.is_empty() {
+            let scalar_value =
+                array
+                    .iter()
+                    .next()
+                    .copied()
+                    .ok_or_else(|| RossbyError::DataNotFound {
+                        message: format!("Scalar variable {} has no data", var_name),
+                    })?;
+            *array = Array::from_elem(IxDyn(&reference_shape), scalar_value);
+        }
+
+        if array.shape() != reference_shape.as_slice() {
+            return Err(RossbyError::InvalidParameter {
+                param: "vars".to_string(),
+                message: format!(
+                    "Requested variables resolve to incompatible shapes: {} has {:?}, expected {:?}",
+                    var_name,
+                    array.shape(),
+                    reference_shape
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 /// Extract data based on the query and format it as Arrow
 fn extract_and_format_data(state: Arc<AppState>, query: ParsedDataQuery) -> Result<Vec<u8>> {
     let ParsedDataQuery {
@@ -976,22 +1073,13 @@ fn extract_and_format_data(state: Arc<AppState>, query: ParsedDataQuery) -> Resu
         }
     }
 
-    // For dimensions not explicitly selected, use the entire range
-    for (dim_name, dim) in &state.metadata.dimensions {
-        if !selected_ranges.contains_key(dim_name) {
-            selected_ranges.insert(dim_name.clone(), (0, dim.size - 1));
-
-            // Store all coordinate values
-            if let Some(coords) = state.get_coordinate(dim_name) {
-                coordinate_arrays.insert(dim_name.clone(), coords.clone());
-            } else {
-                // If no coordinates are available, create a range of indices as coordinates
-                // This is a fallback for test data that might not have explicit coordinate variables
-                let indices: Vec<f64> = (0..dim.size).map(|i| i as f64).collect();
-                coordinate_arrays.insert(dim_name.clone(), indices);
-            }
-        }
-    }
+    let dimension_order = determine_dimension_order(&state, &variables, layout.as_ref())?;
+    populate_query_coordinates(
+        &state,
+        &dimension_order,
+        &mut selected_ranges,
+        &mut coordinate_arrays,
+    )?;
 
     // Calculate the total number of data points to check against limit
     let total_points: usize = coordinate_arrays
@@ -1014,25 +1102,7 @@ fn extract_and_format_data(state: Arc<AppState>, query: ParsedDataQuery) -> Resu
         let array = extract_variable_data(&state, var_name, &selected_ranges)?;
         var_data_arrays.push(array);
     }
-
-    // Get dimensions based on the first variable for use in Arrow schema
-    // Or use layout order if specified
-    let dimension_order = if let Some(layout_dims) = &layout {
-        // Convert layout names to file-specific names
-        layout_dims
-            .iter()
-            .map(|dim| state.resolve_dimension(dim).unwrap_or(dim).to_string())
-            .collect::<Vec<_>>()
-    } else if !variables.is_empty() {
-        // Use dimensions from the first variable
-        let var_meta = state.get_variable_metadata_checked(&variables[0])?;
-        var_meta.dimensions.clone()
-    } else {
-        return Err(RossbyError::InvalidParameter {
-            param: "vars".to_string(),
-            message: "No valid variables specified".to_string(),
-        });
-    };
+    normalize_variable_arrays(&state, &variables, &mut var_data_arrays)?;
 
     // Convert coordinate arrays HashMap to vectors in dimension order
     let mut ordered_dimension_names = Vec::new();
@@ -1365,6 +1435,27 @@ mod tests {
         Arc::new(AppState::new(config, metadata, data))
     }
 
+    fn create_test_state_with_scalar(max_data_points: usize) -> Arc<AppState> {
+        let mut state = create_test_state().as_ref().clone();
+
+        state.metadata.variables.insert(
+            "offset".to_string(),
+            Variable {
+                name: "offset".to_string(),
+                dimensions: Vec::new(),
+                shape: Vec::new(),
+                attributes: HashMap::new(),
+                dtype: "f32".to_string(),
+            },
+        );
+        state
+            .data
+            .insert("offset".to_string(), Array::from_elem(IxDyn(&[]), 273.15));
+        state.config.server.max_data_points = max_data_points;
+
+        Arc::new(state)
+    }
+
     #[test]
     fn test_dimension_selector_parsing() {
         // Create a test state
@@ -1450,5 +1541,34 @@ mod tests {
 
         // Make sure the length is significant (it should be more than just headers)
         assert!(arrow_data.len() > 100);
+    }
+
+    #[test]
+    fn test_extract_and_format_data_with_scalar_first() {
+        let state = create_test_state_with_scalar(1000);
+        let query = ParsedDataQuery {
+            variables: vec!["offset".to_string(), "t2m".to_string()],
+            dimension_selectors: vec![DimensionSelector::SingleIndex {
+                dimension: "time".to_string(),
+                index: 0,
+            }],
+            layout: None,
+        };
+
+        let arrow_data = extract_and_format_data(state, query).unwrap();
+        assert!(!arrow_data.is_empty());
+    }
+
+    #[test]
+    fn test_extract_and_format_scalar_only_ignores_unrelated_dimensions() {
+        let state = create_test_state_with_scalar(1);
+        let query = ParsedDataQuery {
+            variables: vec!["offset".to_string()],
+            dimension_selectors: Vec::new(),
+            layout: None,
+        };
+
+        let arrow_data = extract_and_format_data(state, query).unwrap();
+        assert!(!arrow_data.is_empty());
     }
 }

--- a/tests/common/test_data.rs
+++ b/tests/common/test_data.rs
@@ -441,6 +441,27 @@ pub fn create_test_weather_nc(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Creates a weather NetCDF file and appends a scalar variable.
+///
+/// # Arguments
+///
+/// * `path` - The path where the NetCDF file will be saved
+///
+/// # Returns
+///
+/// * `Result<()>` - Ok if successful, or an error
+pub fn create_test_weather_with_scalar_nc(path: &Path) -> Result<()> {
+    create_test_weather_nc(path)?;
+
+    let mut file = netcdf::append(path)?;
+    let mut offset_var = file.add_variable::<f32>("offset", &[])?;
+    offset_var.put_attribute("units", "K")?;
+    offset_var.put_attribute("long_name", "Scalar Offset")?;
+    offset_var.put_value(273.15f32, ())?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -510,5 +531,18 @@ mod tests {
         assert!(nc_file.variable("v_wind").is_some());
         assert!(nc_file.variable("pressure").is_some());
         assert!(nc_file.variable("precipitation").is_some());
+    }
+
+    #[test]
+    fn test_create_test_weather_with_scalar_nc() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("weather_scalar_test.nc");
+
+        assert!(create_test_weather_with_scalar_nc(&file_path).is_ok());
+        assert!(file_path.exists());
+
+        let nc_file = netcdf::open(&file_path).unwrap();
+        let offset = nc_file.variable("offset").unwrap();
+        assert!(offset.dimensions().is_empty());
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -434,12 +434,9 @@ async fn test_data_endpoint() {
     assert_eq!(response.status(), 200);
 
     // Test with layout specification (Arrow format)
-    let response = http_client::get(
-        &addr,
-        "/data?vars=temperature&time_index=0&layout=latitude,longitude",
-    )
-    .await
-    .expect("Failed to make request");
+    let response = http_client::get(&addr, "/data?vars=temperature&time_index=0&layout=lat,lon")
+        .await
+        .expect("Failed to make request");
 
     assert_eq!(response.status(), 200);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,6 +6,7 @@ mod common;
 
 use common::{http_client, image_utils, test_data};
 use std::net::SocketAddr;
+use std::path::Path;
 
 // Global test setup for server
 use once_cell::sync::OnceCell;
@@ -13,58 +14,18 @@ use once_cell::sync::OnceCell;
 static TEST_TEMP_DIR: OnceCell<tempfile::TempDir> = OnceCell::new();
 static TEST_FILE_PATH: OnceCell<String> = OnceCell::new();
 
-/// Start a test server on a specified port
-async fn start_test_server() -> SocketAddr {
-    // Initialize test data and get temp directory
-    let _temp_dir = TEST_TEMP_DIR.get_or_init(|| {
-        let dir = tempfile::tempdir().unwrap();
-        let file_path = dir.path().join("test_weather.nc");
-        test_data::create_test_weather_nc(&file_path).unwrap();
-
-        // Save the path for later reference
-        TEST_FILE_PATH
-            .set(file_path.to_string_lossy().to_string())
-            .unwrap();
-
-        dir
-    });
-
+async fn spawn_test_server(app_state: rossby::state::AppState) -> SocketAddr {
     // Use port 0 to let the OS assign an available port
     let addr = SocketAddr::from((std::net::Ipv4Addr::new(127, 0, 0, 1), 0));
 
-    // Start by creating a listener to get the OS-assigned port
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("Failed to bind to port");
 
-    // Get the actual bound address with the OS-assigned port
     let bound_addr = listener.local_addr().expect("Failed to get local address");
+    let state = std::sync::Arc::new(app_state);
 
-    // Get the test file path
-    let file_path = TEST_FILE_PATH.get().expect("Test file path not set");
-
-    // Start the server
     tokio::spawn(async move {
-        // Create a minimal config
-        let config = rossby::Config {
-            server: rossby::config::ServerConfig {
-                host: "127.0.0.1".to_string(),
-                port: bound_addr.port(),
-                workers: Some(1),
-                discovery_url: None,
-                max_data_points: 10_000_000, // Default 10 million points
-            },
-            ..Default::default()
-        };
-
-        // Load the test NetCDF file
-        let app_state =
-            rossby::data_loader::load_netcdf(std::path::Path::new(file_path), config.clone())
-                .expect("Failed to load test NetCDF file");
-
-        let state = std::sync::Arc::new(app_state);
-
-        // Create the router
         let app = axum::Router::new()
             .route(
                 "/metadata",
@@ -91,10 +52,48 @@ async fn start_test_server() -> SocketAddr {
         axum::serve(listener, app).await.expect("Server error");
     });
 
-    // The server will take some time to start up fully
     println!("Test server starting on {}", bound_addr);
 
     bound_addr
+}
+
+async fn start_test_server_for_file(path: &Path, max_data_points: usize) -> SocketAddr {
+    let config = rossby::Config {
+        server: rossby::config::ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            workers: Some(1),
+            discovery_url: None,
+            max_data_points,
+        },
+        ..Default::default()
+    };
+
+    let app_state =
+        rossby::data_loader::load_netcdf(path, config).expect("Failed to load test NetCDF file");
+
+    spawn_test_server(app_state).await
+}
+
+/// Start a test server on a specified port
+async fn start_test_server() -> SocketAddr {
+    // Initialize test data and get temp directory
+    let _temp_dir = TEST_TEMP_DIR.get_or_init(|| {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test_weather.nc");
+        test_data::create_test_weather_nc(&file_path).unwrap();
+
+        // Save the path for later reference
+        TEST_FILE_PATH
+            .set(file_path.to_string_lossy().to_string())
+            .unwrap();
+
+        dir
+    });
+
+    // Get the test file path
+    let file_path = TEST_FILE_PATH.get().expect("Test file path not set");
+    start_test_server_for_file(Path::new(file_path), 10_000_000).await
 }
 
 /// Initialize a new test server for each test
@@ -175,6 +174,46 @@ async fn test_metadata_endpoint() {
     let variables = json.get("variables").unwrap();
     assert!(variables.get("temperature").is_some());
     assert!(variables.get("humidity").is_some());
+}
+
+#[tokio::test]
+async fn test_metadata_endpoint_with_scalar_variable() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test_weather_scalar.nc");
+    test_data::create_test_weather_with_scalar_nc(&file_path).unwrap();
+
+    let addr = start_test_server_for_file(&file_path, 10_000_000).await;
+
+    let response = http_client::get(&addr, "/metadata")
+        .await
+        .expect("Failed to make request");
+
+    assert_eq!(response.status(), 200);
+
+    let body = response.text().await.expect("Failed to get response body");
+    let json: serde_json::Value =
+        serde_json::from_str(&body).expect("Failed to parse JSON response");
+
+    let offset = json
+        .get("variables")
+        .and_then(|vars| vars.get("offset"))
+        .expect("Missing scalar variable metadata");
+    assert_eq!(
+        offset
+            .get("dimensions")
+            .and_then(|dims| dims.as_array())
+            .unwrap()
+            .len(),
+        0
+    );
+    assert_eq!(
+        offset
+            .get("shape")
+            .and_then(|shape| shape.as_array())
+            .unwrap()
+            .len(),
+        0
+    );
 }
 
 #[tokio::test]
@@ -525,6 +564,61 @@ async fn test_data_endpoint() {
         .expect("Failed to make request");
 
     assert_eq!(response.status(), 400);
+}
+
+#[tokio::test]
+async fn test_data_endpoint_with_scalar_variable() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("test_weather_scalar.nc");
+    test_data::create_test_weather_with_scalar_nc(&file_path).unwrap();
+
+    let addr = start_test_server_for_file(&file_path, 10_000_000).await;
+
+    let response = http_client::get(&addr, "/data?vars=offset&format=json")
+        .await
+        .expect("Failed to make request");
+
+    assert_eq!(response.status(), 200);
+    let body = response.text().await.expect("Failed to get response body");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+
+    assert_eq!(
+        json["metadata"]["dimensions"]
+            .as_array()
+            .expect("dimensions should be an array")
+            .len(),
+        0
+    );
+    let offset_data = json["data"]["offset"]
+        .as_array()
+        .expect("offset data should be an array");
+    assert_eq!(offset_data.len(), 1);
+    assert!((offset_data[0].as_f64().unwrap() - 273.15).abs() < 1e-6);
+
+    let response = http_client::get(
+        &addr,
+        "/data?vars=offset,temperature&time_index=0&format=json",
+    )
+    .await
+    .expect("Failed to make request");
+
+    assert_eq!(response.status(), 200);
+    let body = response.text().await.expect("Failed to get response body");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+
+    let offset_data = json["data"]["offset"]
+        .as_array()
+        .expect("offset data should be an array");
+    let temp_data = json["data"]["temperature"]
+        .as_array()
+        .expect("temperature data should be an array");
+    assert_eq!(offset_data.len(), temp_data.len());
+    assert!(offset_data.iter().all(|value| {
+        value
+            .as_f64()
+            .map(|n| (n - 273.15).abs() < 1e-6)
+            .unwrap_or(false)
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- remove the validation that rejected variables with no dimensions so scalar NetCDF variables are accepted
- normalize scalar variable arrays by broadcasting them to match the batch shape before JSON/Arrow export
- add coverage verifying scalar loading and extraction when scalars appear before or alone in queries

## Testing

TODO